### PR TITLE
解决了菜单栏鼠标悬浮时看不清文字

### DIFF
--- a/purple.css
+++ b/purple.css
@@ -469,3 +469,11 @@ footer {
 .sidebar-content-content {
   font-size: 0.9rem;
 }
+
+/* Unibody 菜单栏  */
+.megamenu-menu-list:not(.saved) li a:hover,
+.megamenu-menu-list li a.active {
+    background-color: #202B33;
+    color: white;
+}
+


### PR DESCRIPTION
https://github.com/hliu202/typora-purple-theme/issues/17